### PR TITLE
Fix row order when decoding interlaced gif

### DIFF
--- a/AvaloniaGif/Decoding/GifDecoder.cs
+++ b/AvaloniaGif/Decoding/GifDecoder.cs
@@ -210,13 +210,14 @@ namespace AvaloniaGif.Decoding
 
             if (curFrame.IsInterlaced)
             {
+                int curSrcRow = 0;
                 for (var i = 0; i < 4; i++)
                 {
                     var curPass = Pass[i];
                     var y = curPass.Start;
                     while (y < cH)
                     {
-                        DrawRow(y);
+                        DrawRow(curSrcRow++, y);
                         y += curPass.Step;
                     }
                 }
@@ -224,17 +225,17 @@ namespace AvaloniaGif.Decoding
             else
             {
                 for (var i = 0; i < cH; i++)
-                    DrawRow(i);
+                    DrawRow(i, i);
             }
 
             //for (var row = 0; row < cH; row++)
-            void DrawRow(int row)
+            void DrawRow(int srcRow, int destRow)
             {
                 // Get the starting point of the current row on frame's index stream.
-                var indexOffset = row * cW;
+                var indexOffset = srcRow * cW;
 
                 // Get the target backbuffer offset from the frames coords.
-                var targetOffset = PixCoord(cX, row + cY);
+                var targetOffset = PixCoord(cX, destRow + cY);
                 var len = _bitmapBackBuffer.Length;
 
                 for (var i = 0; i < cW; i++)


### PR DESCRIPTION
Currently, Avalonia.GIF doesn't appear to be decoding interlaced GIFs correctly. It looks like the original code does the math correctly, but then incorrectly re-uses the same row index for both the raw GIF data as well as the destination bitmap--as a result, the output remains interlaced.

The fix is simple enough, just need to add a counter in order to differentiate between rows from the source GIF data, and rows in the destination bitmap.

Here's an (ancient) sample interlaced gif for testing:

http://www.quarkist.com/ARCH/W1/FRAME_N/LTOPS/ltop07.htm

Note that this is a single frame GIF--the demo project balks at it due to a separate issue; a division by zero in the timing logic around line 134 of GifInstance.cs. For the sake of testing, I just set timeModulus to TimeSpan.Zero since animation logic wasn't relevant here.

(I'm using GifDecoder directly in my project, so I didn't encounter the latter issue until testing for this PR).

Thanks for reading.
—Daniel