### PR TITLE
Only read global color table when one is present

### DIFF
--- a/AvaloniaGif/Decoding/GifDecoder.cs
+++ b/AvaloniaGif/Decoding/GifDecoder.cs
@@ -458,7 +458,8 @@ namespace AvaloniaGif.Decoding
                 Dimensions = _gifDimensions,
                 HasGlobalColorTable = _gctUsed,
                 // GlobalColorTableCacheID = _globalColorTable,
-                GlobarColorTable = ProcessColorTable(ref str, tmpB, _gctSize),
+                GlobarColorTable =
+                    _gctUsed ? ProcessColorTable(ref str, tmpB, _gctSize) : Array.Empty<GifColor>(),
                 GlobalColorTableSize = _gctSize,
                 BackgroundColorIndex = _bgIndex,
                 HeaderSize = _fileStream.Position


### PR DESCRIPTION
This was a bug I encountered when attempting to decode gifs encoded with ScreenToGif's default settings. Essentially, the code is currently always attempting to read a global color table, even if the flag in the header is unset. This is a subtle bug, as it often has no consequences--garbage data in an unused global color table doesn't cause problems.

However, the sneaky part here is that reading the global color table also advances the file stream's position. Avalonia.GIF's current code will interpret this as an extraneous microblock, and start skipping over until it sees a 0 byte. In the worst case, this results in entire frames being skipped. This is especially noticeable with optimized gifs that rely on drawing over pixels from previous frames, such as ones created by ScreenToGif's default settings.

Here's a sample GIF I encoded for the sake of testing. If you drop this into the demo project, you should notice the missing first frame, which causes the subsequent frames to have a lot of missing pixels. This PR should fix the issue.

![louiscole](https://github.com/AvaloniaUI/Avalonia.GIF/assets/12925039/fc2cb00b-0862-4a7a-91b0-3d0615f6f570)

(This one was a tricky find!)