### PR TITLE
updated nuget packages and set target framework to netstandard2.1

### DIFF
--- a/Avalonia.Gif.Demo/Avalonia.Gif.Demo.csproj
+++ b/Avalonia.Gif.Demo/Avalonia.Gif.Demo.csproj
@@ -14,10 +14,10 @@
     <AvaloniaResource Include="**\*.gif" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.0" /> 
+    <PackageReference Include="Avalonia" Version="11.1.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.3" /> 
     <ProjectReference Include="..\Avalonia.Gif\Avalonia.Gif.csproj" />
   </ItemGroup>
 </Project>

--- a/Avalonia.Gif.Test/Avalonia.Gif.Test.csproj
+++ b/Avalonia.Gif.Test/Avalonia.Gif.Test.csproj
@@ -16,15 +16,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="ApprovalTests" Version="5.2.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="nunit" Version="4.2.2" />
+    <PackageReference Include="ApprovalTests" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
 
-    <PackageReference Include="Avalonia" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0" />
+    <PackageReference Include="Avalonia" Version="11.1.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Avalonia.Gif/Avalonia.Gif.csproj
+++ b/Avalonia.Gif/Avalonia.Gif.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <LangVersion>11</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>

--- a/Avalonia.Gif/Avalonia.Gif.csproj
+++ b/Avalonia.Gif/Avalonia.Gif.csproj
@@ -9,7 +9,7 @@
         <InternalsVisibleTo Include="Avalonia.Gif.Test"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.1.0"/>
+        <PackageReference Include="Avalonia" Version="11.1.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
If a library targets netstandard2.1, it can be used with any dotnet version. There is no need to build libraries for specific dotnet versions. There are too many of them, and Avalonia.Gif supports only one for some reason.

It would be even better to target netstandard2.0, but Avalonia.Gif is using some features from netstandard2.1 such as ranges and System.Array methods.